### PR TITLE
Refactor Handlers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor
 .vscode
 .idea
 debug
+.go-version
 
 
 # Fresh build files

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
 	github.com/sirupsen/logrus v1.9.0
+	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.18.0
 )
@@ -19,13 +20,16 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9Y
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
@@ -41,10 +45,16 @@ github.com/prometheus/common v0.45.0 h1:2BGz0eBc2hdMDLnO/8n0jeB3oPrt2D08CekT0lne
 github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGyv9MZjVOJsY=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
@@ -69,6 +79,8 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
 gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=

--- a/internal/api/entity_handlers.go
+++ b/internal/api/entity_handlers.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"dns-api-go/internal/services"
+	"dns-api-go/logger"
+	"encoding/json"
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+	"net/http"
+	"strconv"
+)
+
+// GetEntityByIdHandler handles GET requests for retrieving an entity by ID.
+func (s *server) GetEntityByIdHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract entity ID parameter from the request URL
+	vars := mux.Vars(r)
+	idStr, idOk := vars["id"]
+
+	// Validate the presence of the required 'id' parameter
+	if !idOk {
+		logger.Warn("Missing required parameter: id",
+			zap.String("method", r.Method))
+		http.Error(w, "Missing required parameter: id", http.StatusBadRequest)
+		return
+	}
+	// Convert id from string to int
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		logger.Error("Invalid ID format",
+			zap.String("id", idStr),
+			zap.Error(err))
+		http.Error(w, "Invalid ID format", http.StatusBadRequest)
+		return
+	}
+
+	// Default includeHA to "true" if not specified
+	includeHAStr := r.URL.Query().Get("includeHA")
+	includeHA, err := strconv.ParseBool(includeHAStr)
+	if err != nil {
+		includeHA = true
+	}
+
+	// Attempt to retrieve the entity by ID and handle potential errors
+	entity, err := s.services.BaseService.GetEntityByID(id, includeHA)
+	if err != nil {
+		// Log the error and respond with appropriate HTTP status
+		logger.Error("Error retrieving entity by ID",
+			zap.Int("id", id),
+			zap.Bool("includeHA", includeHA),
+			zap.String("method", r.Method),
+			zap.Error(err))
+
+		// Determine the type of error and set the HTTP response accordingly
+		switch e := err.(type) {
+		case *services.ErrEntityNotFound:
+			http.Error(w, e.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Serialize the entity to JSON and send it in the response
+	jsonResponse, err := json.Marshal(entity)
+	if err != nil {
+		// Log the error and respond with an internal server error status
+		logger.Error("Failed to marshal entity into JSON", zap.Error(err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Successfully retrieved and marshaled entity; sending back to client
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(jsonResponse); err != nil {
+		// Log failure to write the response
+		logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+// DeleteEntityByIdHandler handles DELETE requests for deleting an entity by ID.
+func (s *server) DeleteEntityByIdHandler(w http.ResponseWriter, r *http.Request) {
+	// Extract entity ID parameter from the request URL
+	vars := mux.Vars(r)
+	idStr, idOk := vars["id"]
+
+	// Validate the presence of the required 'id' parameter
+	if !idOk {
+		logger.Warn("Missing required parameter: id",
+			zap.String("method", r.Method))
+		http.Error(w, "Missing required parameter: id", http.StatusBadRequest)
+		return
+	}
+	// Convert id from string to int
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		logger.Error("Invalid ID format",
+			zap.String("id", idStr),
+			zap.Error(err))
+		http.Error(w, "Invalid ID format", http.StatusBadRequest)
+		return
+	}
+
+	// Attempt to delete the entity by ID and handle potential errors
+	err = s.services.BaseService.DeleteEntityByID(id)
+	if err != nil {
+		// Log the error and respond with appropriate HTTP status
+		logger.Error("Error deleting entity by ID",
+			zap.Int("id", id),
+			zap.String("method", r.Method),
+			zap.Error(err))
+
+		// Determine the type of error and set the HTTP response accordingly
+		switch e := err.(type) {
+		case *services.ErrDeleteNotAllowed:
+			http.Error(w, e.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	// Successfully deleted the entity; acknowledging with no content status
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/api/entity_handlers_test.go
+++ b/internal/api/entity_handlers_test.go
@@ -22,7 +22,7 @@ func TestParseEntityParams(t *testing.T) {
 	}{
 		{
 			name: "Valid ID and includeHA",
-			url:  "/entity/1",
+			url:  "/id/1",
 			queryParams: url.Values{
 				"includeHA": []string{"false"},
 			},
@@ -34,7 +34,7 @@ func TestParseEntityParams(t *testing.T) {
 		},
 		{
 			name:        "Valid ID without includeHA",
-			url:         "/entity/1",
+			url:         "/id/1",
 			queryParams: url.Values{},
 			expectedParams: &EntityParams{
 				ID:        1,
@@ -44,21 +44,21 @@ func TestParseEntityParams(t *testing.T) {
 		},
 		{
 			name:           "Missing ID parameter",
-			url:            "/entity",
+			url:            "/id",
 			queryParams:    url.Values{},
 			expectedParams: nil,
 			expectedError:  "missing required parameter: id",
 		},
 		{
 			name:           "Invalid ID format",
-			url:            "/entity/invalid",
+			url:            "/id/invalid",
 			queryParams:    url.Values{},
 			expectedParams: nil,
 			expectedError:  "invalid ID format",
 		},
 		{
 			name: "Invalid includeHA format",
-			url:  "/entity/1",
+			url:  "/id/1",
 			queryParams: url.Values{
 				"includeHA": []string{"invalid"},
 			},
@@ -77,7 +77,7 @@ func TestParseEntityParams(t *testing.T) {
 
 			// Create a new router and register the route
 			router := mux.NewRouter()
-			router.HandleFunc("/entity/{id}", func(w http.ResponseWriter, r *http.Request) {
+			router.HandleFunc("/id/{id}", func(w http.ResponseWriter, r *http.Request) {
 				params, err := parseEntityParams(r)
 				if tc.expectedError != "" {
 					assert.Nil(t, params)

--- a/internal/api/entity_handlers_test.go
+++ b/internal/api/entity_handlers_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"dns-api-go/internal/models"
+	"dns-api-go/internal/services"
+	"errors"
+	"net/http"
+	"testing"
+)
+
+func TestGetEntityIDHandler(t *testing.T) {
+	tests := []struct {
+		name           string
+		id             string
+		includeHA      string
+		mockEntity     *models.Entity
+		mockError      error
+		expectedBody   string
+		expectedStatus int
+	}{
+		{
+			name:      "Successful retrieval",
+			id:        "1",
+			includeHA: "true",
+			mockEntity: &models.Entity{
+				ID:         1,
+				Name:       "Test Entity",
+				Type:       "TestType",
+				Properties: "TestProperties",
+			},
+			mockError:      nil,
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"ID":1,"Name":"Test Entity","Type":"TestType","Properties":"TestProperties"}`,
+		},
+		{
+			name:      "Missing includeHA",
+			id:        "1",
+			includeHA: "",
+			mockEntity: &models.Entity{
+				ID:         1,
+				Name:       "Test Entity",
+				Type:       "TestType",
+				Properties: "TestProperties",
+			},
+			mockError:      nil,
+			expectedStatus: http.StatusOK,
+			expectedBody:   `{"ID":1,"Name":"Test Entity","Type":"TestType","Properties":"TestProperties"}`,
+		},
+		{
+			name:           "Invalid ID format",
+			id:             "invalid",
+			includeHA:      "true",
+			mockEntity:     nil,
+			mockError:      nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   "Invalid ID format\n",
+		},
+		{
+			name:           "Entity not found",
+			id:             "999",
+			includeHA:      "true",
+			mockEntity:     nil,
+			mockError:      &services.ErrEntityNotFound{},
+			expectedStatus: http.StatusNotFound,
+			expectedBody:   "Entity not found\n",
+		},
+		{
+			name:           "GetEntityByID server error",
+			id:             "2",
+			includeHA:      "true",
+			mockEntity:     nil,
+			mockError:      errors.New("internal error"),
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "internal error\n",
+		},
+		{
+			name:           "Marshaling error",
+			id:             "1",
+			includeHA:      "true",
+			mockEntity:     &models.Entity{},
+			mockError:      nil,
+			expectedStatus: http.StatusInternalServerError,
+			expectedBody:   "Internal server error\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// TODO: Implement the test
+		})
+	}
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -18,15 +18,12 @@ package api
 
 import (
 	"crypto/tls"
-	"dns-api-go/internal/services"
 	"encoding/json"
 	"fmt"
-	"github.com/gorilla/mux"
 	"go.uber.org/zap"
 	"io"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -230,122 +227,6 @@ func (s *server) GetRecordHintHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Write the response body as-is
 	w.Write(body)
-}
-
-// GetEntityByIdHandler handles GET requests for retrieving an entity by ID.
-func (s *server) GetEntityByIdHandler(w http.ResponseWriter, r *http.Request) {
-	// Extract entity ID parameter from the request URL
-	vars := mux.Vars(r)
-	idStr, idOk := vars["id"]
-
-	// Validate the presence of the required 'id' parameter
-	if !idOk {
-		logger.Warn("Missing required parameter: id",
-			zap.String("method", r.Method))
-		http.Error(w, "Missing required parameter: id", http.StatusBadRequest)
-		return
-	}
-	// Convert id from string to int
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		logger.Error("Invalid ID format",
-			zap.String("id", idStr),
-			zap.Error(err))
-		http.Error(w, "Invalid ID format", http.StatusBadRequest)
-		return
-	}
-
-	// Default includeHA to "true" if not specified
-	includeHAStr := r.URL.Query().Get("includeHA")
-	includeHA, err := strconv.ParseBool(includeHAStr)
-	if err != nil {
-		includeHA = true
-	}
-
-	// Attempt to retrieve the entity by ID and handle potential errors
-	entity, err := s.services.BaseService.GetEntityByID(id, includeHA)
-	if err != nil {
-		// Log the error and respond with appropriate HTTP status
-		logger.Error("Error retrieving entity by ID",
-			zap.Int("id", id),
-			zap.Bool("includeHA", includeHA),
-			zap.String("method", r.Method),
-			zap.Error(err))
-
-		// Determine the type of error and set the HTTP response accordingly
-		switch e := err.(type) {
-		case *services.ErrEntityNotFound:
-			http.Error(w, e.Error(), http.StatusNotFound)
-			return
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	}
-
-	// Serialize the entity to JSON and send it in the response
-	jsonResponse, err := json.Marshal(entity)
-	if err != nil {
-		// Log the error and respond with an internal server error status
-		logger.Error("Failed to marshal entity into JSON", zap.Error(err))
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	// Successfully retrieved and marshaled entity; sending back to client
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(jsonResponse); err != nil {
-		// Log failure to write the response
-		logger.Error("Failed to write response", zap.Error(err))
-	}
-}
-
-// DeleteEntityByIdHandler handles DELETE requests for deleting an entity by ID.
-func (s *server) DeleteEntityByIdHandler(w http.ResponseWriter, r *http.Request) {
-	// Extract entity ID parameter from the request URL
-	vars := mux.Vars(r)
-	idStr, idOk := vars["id"]
-
-	// Validate the presence of the required 'id' parameter
-	if !idOk {
-		logger.Warn("Missing required parameter: id",
-			zap.String("method", r.Method))
-		http.Error(w, "Missing required parameter: id", http.StatusBadRequest)
-		return
-	}
-	// Convert id from string to int
-	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		logger.Error("Invalid ID format",
-			zap.String("id", idStr),
-			zap.Error(err))
-		http.Error(w, "Invalid ID format", http.StatusBadRequest)
-		return
-	}
-
-	// Attempt to delete the entity by ID and handle potential errors
-	err = s.services.BaseService.DeleteEntityByID(id)
-	if err != nil {
-		// Log the error and respond with appropriate HTTP status
-		logger.Error("Error deleting entity by ID",
-			zap.Int("id", id),
-			zap.String("method", r.Method),
-			zap.Error(err))
-
-		// Determine the type of error and set the HTTP response accordingly
-		switch e := err.(type) {
-		case *services.ErrDeleteNotAllowed:
-			http.Error(w, e.Error(), http.StatusNotFound)
-			return
-		default:
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-			return
-		}
-	}
-
-	// Successfully deleted the entity; acknowledging with no content status
-	w.WriteHeader(http.StatusNoContent)
 }
 
 // VersionHandler responds to version requests

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -18,9 +18,6 @@ package api
 
 import (
 	"dns-api-go/internal/common"
-	"dns-api-go/internal/models"
-	"dns-api-go/internal/services"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -87,88 +84,5 @@ func TestVersionHandler(t *testing.T) {
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), expected)
-	}
-}
-
-func TestGetEntityIDHandler(t *testing.T) {
-	tests := []struct {
-		name           string
-		id             string
-		includeHA      string
-		mockEntity     *models.Entity
-		mockError      error
-		expectedBody   string
-		expectedStatus int
-	}{
-		{
-			name:      "Successful retrieval",
-			id:        "1",
-			includeHA: "true",
-			mockEntity: &models.Entity{
-				ID:         1,
-				Name:       "Test Entity",
-				Type:       "TestType",
-				Properties: "TestProperties",
-			},
-			mockError:      nil,
-			expectedStatus: http.StatusOK,
-			expectedBody:   `{"ID":1,"Name":"Test Entity","Type":"TestType","Properties":"TestProperties"}`,
-		},
-		{
-			name:      "Missing includeHA",
-			id:        "1",
-			includeHA: "",
-			mockEntity: &models.Entity{
-				ID:         1,
-				Name:       "Test Entity",
-				Type:       "TestType",
-				Properties: "TestProperties",
-			},
-			mockError:      nil,
-			expectedStatus: http.StatusOK,
-			expectedBody:   `{"ID":1,"Name":"Test Entity","Type":"TestType","Properties":"TestProperties"}`,
-		},
-		{
-			name:           "Invalid ID format",
-			id:             "invalid",
-			includeHA:      "true",
-			mockEntity:     nil,
-			mockError:      nil,
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   "Invalid ID format\n",
-		},
-		{
-			name:           "Entity not found",
-			id:             "999",
-			includeHA:      "true",
-			mockEntity:     nil,
-			mockError:      &services.ErrEntityNotFound{},
-			expectedStatus: http.StatusNotFound,
-			expectedBody:   "Entity not found\n",
-		},
-		{
-			name:           "GetEntityByID server error",
-			id:             "2",
-			includeHA:      "true",
-			mockEntity:     nil,
-			mockError:      errors.New("internal error"),
-			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   "internal error\n",
-		},
-		{
-			name:           "Marshaling error",
-			id:             "1",
-			includeHA:      "true",
-			mockEntity:     &models.Entity{},
-			mockError:      nil,
-			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   "Internal server error\n",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			// TODO: Implement the test
-		})
 	}
 }


### PR DESCRIPTION
Its good practice to separate handlers into their own files. For example, handlers related to the base entity service should be in their own file (as well as tests), handlers related to the app (such as ping, version, etc.) will be in the main handlers file. Further handlers that are developed, such as for the zone service, dns service, etc. will need to also be in their own files.

Summation of changes to get started on this:
- Moving handlers related to Base Entity Service (GetEntityByID and DeleteEntityByID) into their own handlers file
- Moving tests for above handlers into their own file
- New test for the parseQueryParameters function that was added inside entity_service_handlers.go
- `handlers.go` should only contain routes that pertain to basics about the application such as ping, version, home, etc.
- GetEntityByIDHandler and DeleteEntityByIDHandler now use structs to accept incoming URL parameters, which is standard go practice