### PR TITLE
Add Network Service

### DIFF
--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -1,0 +1,103 @@
+package api
+
+import (
+	"dns-api-go/logger"
+	"encoding/json"
+	"fmt"
+	"go.uber.org/zap"
+	"net/http"
+	"strconv"
+)
+
+type GetNetworksParams struct {
+	offset int
+	limit  int
+	hint   string
+}
+
+func parseGetNetworksParams(r *http.Request) (*GetNetworksParams, error) {
+	// Set default values
+	offset := 0
+	limit := 10
+	hint := ""
+
+	query := r.URL.Query()
+
+	// Parse offset if it is not empty
+	if offsetStr := query.Get("offset"); offsetStr != "" {
+		parsedOffset, err := strconv.Atoi(offsetStr)
+		// Return error if offset is not a valid integer
+		if err != nil {
+			return nil, fmt.Errorf("invalid offset value: %v", err)
+		}
+		// Return error if offset is negative
+		if parsedOffset < 0 {
+			return nil, fmt.Errorf("offset cannot be negative")
+		}
+		// Override the default value
+		offset = parsedOffset
+	}
+
+	// Parse limit if it is not empty
+	if limitStr := query.Get("limit"); limitStr != "" {
+		parsedLimit, err := strconv.Atoi(limitStr)
+		// Return error if limit is not a valid integer
+		if err != nil {
+			return nil, fmt.Errorf("invalid limit value: %v", err)
+		}
+		// Return error if limit is negative
+		if parsedLimit < 0 {
+			return nil, fmt.Errorf("limit cannot be negative")
+		}
+		// Override the default value
+		limit = parsedLimit
+	}
+
+	// Parse hint if it is not empty
+	if hintStr := query.Get("hint"); hintStr != "" {
+		hint = hintStr
+	}
+
+	return &GetNetworksParams{
+		offset: offset,
+		limit:  limit,
+		hint:   hint,
+	}, nil
+}
+
+func (s *server) GetNetworksHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the entity parameters from the request
+	params, err := parseGetNetworksParams(r)
+	if err != nil {
+		logger.Warn("Invalid request parameters", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Call the service to get networks
+	networks, err := s.services.NetworkService.GetNetworks(params.offset, params.limit, map[string]string{"hint": params.hint})
+	if err != nil {
+		logger.Error("Failed to get networks", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Serialize the networks to JSON
+	jsonResponse, err := json.Marshal(networks)
+	if err != nil {
+		logger.Error("Failed to marshal networks into JSON", zap.Error(err))
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	// Set the response headers and write the JSON response
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	if _, err := w.Write(jsonResponse); err != nil {
+		logger.Error("Failed to write response", zap.Error(err))
+	}
+}
+
+func (s *server) GetNetworkHandler() http.HandlerFunc {
+	return s.HandleGetEntityReq(s.services.NetworkService)
+}

--- a/internal/api/network_handlers.go
+++ b/internal/api/network_handlers.go
@@ -1,101 +1,11 @@
 package api
 
 import (
-	"dns-api-go/logger"
-	"encoding/json"
-	"fmt"
-	"go.uber.org/zap"
 	"net/http"
-	"strconv"
 )
 
-type GetNetworksParams struct {
-	offset int
-	limit  int
-	hint   string
-}
-
-func parseGetNetworksParams(r *http.Request) (*GetNetworksParams, error) {
-	// Set default values
-	offset := 0
-	limit := 10
-	hint := ""
-
-	query := r.URL.Query()
-
-	// Parse offset if it is not empty
-	if offsetStr := query.Get("offset"); offsetStr != "" {
-		parsedOffset, err := strconv.Atoi(offsetStr)
-		// Return error if offset is not a valid integer
-		if err != nil {
-			return nil, fmt.Errorf("invalid offset value: %v", err)
-		}
-		// Return error if offset is negative
-		if parsedOffset < 0 {
-			return nil, fmt.Errorf("offset cannot be negative")
-		}
-		// Override the default value
-		offset = parsedOffset
-	}
-
-	// Parse limit if it is not empty
-	if limitStr := query.Get("limit"); limitStr != "" {
-		parsedLimit, err := strconv.Atoi(limitStr)
-		// Return error if limit is not a valid integer
-		if err != nil {
-			return nil, fmt.Errorf("invalid limit value: %v", err)
-		}
-		// Return error if limit is negative
-		if parsedLimit < 0 {
-			return nil, fmt.Errorf("limit cannot be negative")
-		}
-		// Override the default value
-		limit = parsedLimit
-	}
-
-	// Parse hint if it is not empty
-	if hintStr := query.Get("hint"); hintStr != "" {
-		hint = hintStr
-	}
-
-	return &GetNetworksParams{
-		offset: offset,
-		limit:  limit,
-		hint:   hint,
-	}, nil
-}
-
-func (s *server) GetNetworksHandler(w http.ResponseWriter, r *http.Request) {
-	// Parse the entity parameters from the request
-	params, err := parseGetNetworksParams(r)
-	if err != nil {
-		logger.Warn("Invalid request parameters", zap.Error(err))
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	// Call the service to get networks
-	networks, err := s.services.NetworkService.GetNetworks(params.offset, params.limit, map[string]string{"hint": params.hint})
-	if err != nil {
-		logger.Error("Failed to get networks", zap.Error(err))
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Serialize the networks to JSON
-	jsonResponse, err := json.Marshal(networks)
-	if err != nil {
-		logger.Error("Failed to marshal networks into JSON", zap.Error(err))
-		http.Error(w, "Internal server error", http.StatusInternalServerError)
-		return
-	}
-
-	// Set the response headers and write the JSON response
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	if _, err := w.Write(jsonResponse); err != nil {
-		logger.Error("Failed to write response", zap.Error(err))
-	}
+func (s *server) GetNetworksHandler() http.HandlerFunc {
+	return s.HandleGetEntitiesByHintReq(s.services.NetworkService)
 }
 
 func (s *server) GetNetworkHandler() http.HandlerFunc {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -53,8 +53,8 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/records/{id}", s.ProxyRequestHandler).Methods(http.MethodGet, http.MethodPut, http.MethodDelete)
 
 	// Manage Networks
-	api.HandleFunc("/{account}/networks", s.ProxyRequestHandler).Methods(http.MethodGet)
-	api.HandleFunc("/{account}/networks/{id}", s.ProxyRequestHandler).Methods(http.MethodGet)
+	accountRouter.HandleFunc("/networks", s.GetNetworksHandler).Methods(http.MethodGet)
+	accountRouter.HandleFunc("/networks/{id}", s.GetNetworkHandler()).Methods(http.MethodGet)
 
 	// Manage IP addresses
 	api.HandleFunc("/{account}/ips", s.ProxyRequestHandler).Methods(http.MethodPost)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -53,7 +53,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/records/{id}", s.ProxyRequestHandler).Methods(http.MethodGet, http.MethodPut, http.MethodDelete)
 
 	// Manage Networks
-	accountRouter.HandleFunc("/networks", s.GetNetworksHandler).Methods(http.MethodGet)
+	accountRouter.HandleFunc("/networks", s.GetNetworksHandler()).Methods(http.MethodGet)
 	accountRouter.HandleFunc("/networks/{id}", s.GetNetworkHandler()).Methods(http.MethodGet)
 
 	// Manage IP addresses

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -114,7 +114,7 @@ func NewServer(config common.Config) error {
 	// Define services that interact with Bluecat entities
 	baseService := services.NewBaseService(&s)
 	zoneService := services.NewZoneService(&s)
-	networkService := services.NewNetworkService(&s, baseService, baseService)
+	networkService := services.NewNetworkService(&s, baseService)
 	s.services = Services{
 		BaseService: baseService,
 		ZoneService: zoneService,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -114,7 +114,7 @@ func NewServer(config common.Config) error {
 	// Define services that interact with Bluecat entities
 	baseService := services.NewBaseService(&s)
 	zoneService := services.NewZoneService(&s)
-	networkService := services.NewNetworkService(&s, baseService)
+	networkService := services.NewNetworkService(&s)
 	s.services = Services{
 		BaseService: baseService,
 		ZoneService: zoneService,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -65,6 +65,7 @@ type bluecat struct {
 type Services struct {
 	BaseService *services.BaseService
 	ZoneService *services.ZoneService
+	NetworkService *services.NetworkService
 }
 
 type server struct {
@@ -113,9 +114,11 @@ func NewServer(config common.Config) error {
 	// Define services that interact with Bluecat entities
 	baseService := services.NewBaseService(&s)
 	zoneService := services.NewZoneService(&s)
+	networkService := services.NewNetworkService(&s, baseService, baseService)
 	s.services = Services{
 		BaseService: baseService,
 		ZoneService: zoneService,
+		NetworkService: networkService,
 	}
 
 	if b := config.ProxyBackend; b != nil {

--- a/internal/services/network_service.go
+++ b/internal/services/network_service.go
@@ -1,0 +1,77 @@
+package services
+
+import (
+	"dns-api-go/internal/interfaces"
+	"dns-api-go/internal/models"
+	"dns-api-go/internal/types"
+	"dns-api-go/logger"
+	"encoding/json"
+	"fmt"
+	"go.uber.org/zap"
+	"strings"
+)
+
+type NetworkEntityService interface {
+	GetNetworks(start int, count int, options map[string]string) (*[]models.Entity, error)
+	GetEntity(networkId int, includeHA bool) (*models.Entity, error)
+}
+
+type NetworkService struct {
+	server interfaces.ServerInterface
+	EntitiesLister
+	EntityGetter
+}
+
+// NewNetworkService Constructor for NetworkService
+func NewNetworkService(server interfaces.ServerInterface, entitiesLister EntitiesLister, entityGetter EntityGetter) *NetworkService {
+	return &NetworkService{server: server, EntitiesLister: entitiesLister, EntityGetter: entityGetter}
+}
+
+// GetNetworks Retrieves a list of networks from bluecat
+// Note: The maximum that count can be is 10.
+func (ns *NetworkService) GetNetworks(start int, count int, options map[string]string) (*[]models.Entity, error) {
+	logger.Info("GetNetworks started",
+		zap.Int("start", start),
+		zap.Int("count", count),
+		zap.Any("options", options))
+
+	// Retrieve Configuration Id
+	containers, err := ns.GetEntities(0, 1, 0, types.CONFIGURATION, false)
+	if err != nil {
+		return nil, err
+	}
+	if len(*containers) == 0 {
+		return nil, fmt.Errorf("failed to retrieve containerId")
+	}
+	configId := (*containers)[0].ID
+
+	// Construct the request parameters
+	params := fmt.Sprintf("containerId=%d&start=%d&count=%d", configId, start, count)
+	if len(options) > 0 {
+		opts := make([]string, 0, len(options))
+		for key, value := range options {
+			opts = append(opts, fmt.Sprintf("%s=%s", key, value))
+		}
+		params += "&options=" + strings.Join(opts, "|")
+	}
+
+	// Use the configuration ID to call the Bluecat API to get networks
+	route := "/getIP4NetworksByHint"
+	resp, err := ns.server.MakeRequest("GET", route, params)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal the response
+	var networkResp []models.EntityResponse
+	if err := json.Unmarshal(resp, &networkResp); err != nil {
+		logger.Error("Error unmarshalling networks response", zap.Error(err))
+		return nil, err
+	}
+
+	// For each network entity response, convert it to an entity
+	networks := models.ConvertToEntities(networkResp)
+
+	logger.Info("GetNetworks successful", zap.Int("count", len(networks)))
+	return &networks, nil
+}

--- a/internal/services/network_service.go
+++ b/internal/services/network_service.go
@@ -75,3 +75,23 @@ func (ns *NetworkService) GetNetworks(start int, count int, options map[string]s
 	logger.Info("GetNetworks successful", zap.Int("count", len(networks)))
 	return &networks, nil
 }
+
+func (ns *NetworkService) GetEntity(networkId int, includeHA bool) (*models.Entity, error) {
+	logger.Info("GetNetwork started", zap.Int("networkId", networkId))
+
+	// Call EntityGetter
+	entity, err := ns.EntityGetter.GetEntity(networkId, includeHA)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check if the entity type is a network
+	if entity.Type != types.NETWORK {
+		return nil, &ErrEntityTypeMismatch{ExpectedTypes: []string{types.NETWORK}, ActualType: entity.Type}
+	}
+
+	logger.Info("GetNetwork successful",
+		zap.Int("entityId", entity.ID),
+		zap.String("entityType", entity.Type))
+	return entity, nil
+}

--- a/internal/services/network_service.go
+++ b/internal/services/network_service.go
@@ -5,75 +5,40 @@ import (
 	"dns-api-go/internal/models"
 	"dns-api-go/internal/types"
 	"dns-api-go/logger"
-	"encoding/json"
-	"fmt"
 	"go.uber.org/zap"
-	"strings"
 )
 
 type NetworkEntityService interface {
-	GetNetworks(start int, count int, options map[string]string) (*[]models.Entity, error)
+	GetEntityByHint(start int, count int, options map[string]string) (*[]models.Entity, error)
 	GetEntity(networkId int, includeHA bool) (*models.Entity, error)
 }
 
 type NetworkService struct {
 	server interfaces.ServerInterface
-	EntitiesLister
-	EntityGetter
+	interfaces.EntityGetter
 }
 
 // NewNetworkService Constructor for NetworkService
-func NewNetworkService(server interfaces.ServerInterface, entitiesLister EntitiesLister, entityGetter EntityGetter) *NetworkService {
-	return &NetworkService{server: server, EntitiesLister: entitiesLister, EntityGetter: entityGetter}
+func NewNetworkService(server interfaces.ServerInterface, entityGetter interfaces.EntityGetter) *NetworkService {
+	return &NetworkService{server: server, EntityGetter: entityGetter}
 }
 
-// GetNetworks Retrieves a list of networks from bluecat
+// GetEntitiesByHint Retrieves a list of networks from bluecat
 // Note: The maximum that count can be is 10.
-func (ns *NetworkService) GetNetworks(start int, count int, options map[string]string) (*[]models.Entity, error) {
-	logger.Info("GetNetworks started",
+func (ns *NetworkService) GetEntitiesByHint(start int, count int, options map[string]string) (*[]models.Entity, error) {
+	logger.Info("GetEntitiesByHint started",
 		zap.Int("start", start),
 		zap.Int("count", count),
 		zap.Any("options", options))
 
-	// Retrieve Configuration Id
-	containers, err := ns.GetEntities(0, 1, 0, types.CONFIGURATION, false)
-	if err != nil {
-		return nil, err
-	}
-	if len(*containers) == 0 {
-		return nil, fmt.Errorf("failed to retrieve containerId")
-	}
-	configId := (*containers)[0].ID
-
-	// Construct the request parameters
-	params := fmt.Sprintf("containerId=%d&start=%d&count=%d", configId, start, count)
-	if len(options) > 0 {
-		opts := make([]string, 0, len(options))
-		for key, value := range options {
-			opts = append(opts, fmt.Sprintf("%s=%s", key, value))
-		}
-		params += "&options=" + strings.Join(opts, "|")
-	}
-
-	// Use the configuration ID to call the Bluecat API to get networks
 	route := "/getIP4NetworksByHint"
-	resp, err := ns.server.MakeRequest("GET", route, params)
+	networks, err := GetEntitiesByHintHelper(ns.server, route, start, count, options)
 	if err != nil {
 		return nil, err
 	}
 
-	// Unmarshal the response
-	var networkResp []models.EntityResponse
-	if err := json.Unmarshal(resp, &networkResp); err != nil {
-		logger.Error("Error unmarshalling networks response", zap.Error(err))
-		return nil, err
-	}
-
-	// For each network entity response, convert it to an entity
-	networks := models.ConvertToEntities(networkResp)
-
-	logger.Info("GetNetworks successful", zap.Int("count", len(networks)))
-	return &networks, nil
+	logger.Info("GetEntitiesByHint successful", zap.Int("count", len(*networks)))
+	return networks, nil
 }
 
 func (ns *NetworkService) GetEntity(networkId int, includeHA bool) (*models.Entity, error) {

--- a/internal/services/network_service.go
+++ b/internal/services/network_service.go
@@ -15,12 +15,11 @@ type NetworkEntityService interface {
 
 type NetworkService struct {
 	server interfaces.ServerInterface
-	interfaces.EntityGetter
 }
 
 // NewNetworkService Constructor for NetworkService
-func NewNetworkService(server interfaces.ServerInterface, entityGetter interfaces.EntityGetter) *NetworkService {
-	return &NetworkService{server: server, EntityGetter: entityGetter}
+func NewNetworkService(server interfaces.ServerInterface) *NetworkService {
+	return &NetworkService{server: server}
 }
 
 // GetEntitiesByHint Retrieves a list of networks from bluecat
@@ -45,14 +44,9 @@ func (ns *NetworkService) GetEntity(networkId int, includeHA bool) (*models.Enti
 	logger.Info("GetNetwork started", zap.Int("networkId", networkId))
 
 	// Call EntityGetter
-	entity, err := ns.EntityGetter.GetEntity(networkId, includeHA)
+	entity, err := GetEntityByID(ns.server, networkId, includeHA, []string{types.NETWORK})
 	if err != nil {
 		return nil, err
-	}
-
-	// Check if the entity type is a network
-	if entity.Type != types.NETWORK {
-		return nil, &ErrEntityTypeMismatch{ExpectedTypes: []string{types.NETWORK}, ActualType: entity.Type}
 	}
 
 	logger.Info("GetNetwork successful",

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -10,4 +10,5 @@ const (
 	MACADDRESS    = "MACAddress"
 	MACPOOL       = "MACPool"
 	ZONE          = "Zone"
+	NETWORK       = "IP4Network"
 )


### PR DESCRIPTION
# Testing this PR

## Testing the Network Service Routes

To ensure the new Network Service routes are functioning correctly, follow these steps to test each route. Be aware of potential edge cases and ensure comprehensive coverage.

### Testing `GET /:account/networks`

**Purpose:** Retrieve a list of network entities.

**Steps:**
1. **Basic Request:**
   - Send a GET request to `/:account/networks`.
   - Verify that the response status is `200 OK`.
   - Check that the response body contains a JSON array of network entities.

2. **Parameter Testing:**
   - Test with different `offset` and `limit` values in the query parameters.
   - Example: `GET /:account/networks?offset=0&limit=5`.
   - Verify that the response contains the correct number of entities based on the `limit`.
   - **Note:** The maximum value for `limit` is 10.

3. **Hint Parameter:**
   - Test with the `hint` parameter to filter results.
   - Example: `GET /:account/networks?hint=yale`.
   - Verify that the response contains entities matching the hint criteria.
   - **Note:** The `hint` cannot contain spaces.
   - **Explanation:** The `hint` is typically a string that can represent a partial or complete domain name. The API will return networks that match the hint either fully or partially.

4. **Invalid Parameters:**
   - Test with invalid `offset` and `limit` values (e.g., negative numbers, non-integer values).
   - Verify that the response status is `400 Bad Request` and contains an appropriate error message.

5. **Edge Cases:**
   - Test with `offset` and `limit` values that exceed the total number of available entities.
   - Verify that the response is handled gracefully and does not cause errors.

### Testing `GET /:account/networks/:id`

**Purpose:** Retrieve a specific network entity by its ID.

**Steps:**
1. **Basic Request:**
   - Send a GET request to `/:account/networks/:id` with a valid network ID.
   - Verify that the response status is `200 OK`.
   - Check that the response body contains the correct network entity in JSON format.

2. **Invalid ID:**
   - Test with an invalid network ID (e.g., non-existent ID, non-integer value).
   - Verify that the response status is `404 Not Found` or `400 Bad Request` with an appropriate error message.

3. **Type Mismatch:**
   - Ensure that the `GetEntity` method correctly identifies the entity type.
   - Test with an ID that does not correspond to a network entity.
   - Verify that the response status is `400 Bad Request` and contains an `ErrEntityTypeMismatch` error message.

4. **Edge Cases:**
   - Test with boundary values for the network ID (e.g., minimum and maximum possible integer values).
   - Verify that the service handles these cases without errors.