### PR TITLE
Add Mac Address Service

### DIFF
--- a/internal/api/mac_address_handlers.go
+++ b/internal/api/mac_address_handlers.go
@@ -1,0 +1,1 @@
+package api

--- a/internal/api/mac_address_handlers.go
+++ b/internal/api/mac_address_handlers.go
@@ -1,1 +1,168 @@
 package api
+
+import (
+	"dns-api-go/internal/models"
+	"dns-api-go/logger"
+	"encoding/json"
+	"fmt"
+	"github.com/gorilla/mux"
+	"go.uber.org/zap"
+	"net/http"
+	"regexp"
+)
+
+type MacAddressParams struct {
+	Address string
+}
+
+type MacParams struct {
+	Address    string            `json:"mac"`
+	PoolId     int               `json:"macpool"`
+	Properties map[string]string `json:"properties"`
+}
+
+// validateMacAddress validates the format of the MAC address
+// mac address should be in the format: nnnnnnnnnnnn or nn:nn:nn:nn:nn:nn or nn-nn-nn-nn-nn-nn
+func validateMacAddress(macAddress string) error {
+	// Define the regular expression for a valid MAC address
+	macRegex := `^([0-9A-Fa-f]{12}|([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2})$`
+	re := regexp.MustCompile(macRegex)
+
+	// Validate the MAC address format
+	if !re.MatchString(macAddress) {
+		return fmt.Errorf("invalid MAC address format. MAC address should be in the format: nnnnnnnnnnnn or nn:nn:nn:nn:nn:nn or nn-nn-nn-nn-nn-nn")
+	}
+
+	return nil
+}
+
+// parseMacAddressParams parses and validates the parameters from the request.
+func parseMacAddressParams(r *http.Request) (*MacAddressParams, error) {
+	// Extract mac address parameter from the request URL
+	vars := mux.Vars(r)
+	macAddress, macAddressOk := vars["mac"]
+
+	// Validate the presence of the required 'mac' parameter
+	if !macAddressOk {
+		return nil, fmt.Errorf("missing required parameter: mac")
+	}
+	// Make sure mac address is in the correct format
+	if err := validateMacAddress(macAddress); err != nil {
+		return nil, err
+	}
+
+	return &MacAddressParams{Address: macAddress}, nil
+}
+
+// parseMacParams parses and validates the parameters from the request.
+func parseMacParams(r *http.Request) (*MacParams, error) {
+	// Extract the mac address parameter
+	var MacParams MacParams
+	decoder := json.NewDecoder(r.Body)
+	if err := decoder.Decode(&MacParams); err != nil {
+		return nil, fmt.Errorf("failed to decode request body: %v", err)
+	}
+
+	// Validate the presence and format of the mac address
+	if MacParams.Address == "" {
+		return nil, fmt.Errorf("missing required parameter: mac")
+	}
+	if err := validateMacAddress(MacParams.Address); err != nil {
+		return nil, err
+	}
+
+	// Initialize Properties if nil
+	if MacParams.Properties == nil {
+		MacParams.Properties = make(map[string]string)
+	}
+
+	return &MacParams, nil
+}
+
+// GetMacAddressHandler handles GET requests for retrieving a mac address by address.
+func (s *server) GetMacAddressHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the mac parameters from the request
+	params, err := parseMacAddressParams(r)
+	if err != nil {
+		logger.Warn("Invalid request parameters", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Attempt to get the mac address entity and handle potential errors
+	entity, err := s.services.MacAddressService.GetMacAddress(params.Address)
+	if err != nil {
+		logger.Error("Error getting mac address entity", zap.String("macAddress", params.Address), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Successfully retrieved entity; sending back to client
+	s.respond(w, entity, http.StatusOK)
+}
+
+// CreateMacAddressHandler handles POST requests for creating a mac address.
+func (s *server) CreateMacAddressHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the mac parameters from the request
+	params, err := parseMacParams(r)
+	if err != nil {
+		logger.Warn("Invalid request parameters", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Create mac object
+	mac := &models.Mac{
+		Address:    params.Address,
+		PoolId:     params.PoolId,
+		Properties: params.Properties,
+	}
+
+	// Attempt to create the mac address to bluecat and handle potential errors
+	objectId, err := s.services.MacAddressService.CreateMacAddress(*mac)
+	if err != nil {
+		logger.Error("Failed to create mac address", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Send the response back to client with objectId of newly created Mac object
+	s.respond(w, objectId, http.StatusOK)
+}
+
+// UpdateMacAddressHandler handles PUT requests for updating a mac address.
+func (s *server) UpdateMacAddressHandler(w http.ResponseWriter, r *http.Request) {
+	// Parse the mac parameters from the request
+	params, err := parseMacParams(r)
+	if err != nil {
+		logger.Warn("Invalid request parameters", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Get the mac object from inside bluecat to retrieve the properties
+	entity, err := s.services.MacAddressService.GetMacAddress(params.Address)
+	if err != nil {
+		logger.Error("Error getting mac address entity", zap.String("macAddress", params.Address), zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Create mac object with properties from bluecat
+	mac := &models.Mac{
+		Address:    params.Address,
+		PoolId:     params.PoolId,
+		Properties: entity.Properties,
+	}
+
+	// Update the mac object with the new properties
+	err = s.services.MacAddressService.UpdateMacAddress(*mac, params.Properties)
+	if err != nil {
+		logger.Error("Failed to update mac address", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Send the response back to client
+	s.respond(w, nil, http.StatusNoContent)
+}

--- a/internal/api/mac_address_handlers.go
+++ b/internal/api/mac_address_handlers.go
@@ -66,9 +66,6 @@ func parseCreateMacParams(r *http.Request) (*MacParams, error) {
 	}
 
 	// Validate the presence and format of the mac address
-	if MacParams.Address == "" {
-		return nil, fmt.Errorf("missing required parameter: mac")
-	}
 	if err := validateMacAddress(MacParams.Address); err != nil {
 		return nil, err
 	}

--- a/internal/api/mac_address_handlers.go
+++ b/internal/api/mac_address_handlers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"dns-api-go/internal/models"
+	"dns-api-go/internal/services"
 	"dns-api-go/logger"
 	"encoding/json"
 	"fmt"
@@ -128,8 +129,15 @@ func (s *server) GetMacAddressHandler(w http.ResponseWriter, r *http.Request) {
 	entity, err := s.services.MacAddressService.GetMacAddress(params.Address)
 	if err != nil {
 		logger.Error("Error getting mac address entity", zap.String("macAddress", params.Address), zap.Error(err))
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		// Determine the type of error and set the HTTP response accordingly
+		switch e := err.(type) {
+		case *services.ErrEntityNotFound:
+			http.Error(w, e.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Successfully retrieved entity; sending back to client
@@ -179,8 +187,15 @@ func (s *server) UpdateMacAddressHandler(w http.ResponseWriter, r *http.Request)
 	entity, err := s.services.MacAddressService.GetMacAddress(params.Address)
 	if err != nil {
 		logger.Error("Error getting mac address entity", zap.String("macAddress", params.Address), zap.Error(err))
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
+		// Determine the type of error and set the HTTP response accordingly
+		switch e := err.(type) {
+		case *services.ErrEntityNotFound:
+			http.Error(w, e.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// Create mac object with properties from bluecat

--- a/internal/api/mac_address_handlers.go
+++ b/internal/api/mac_address_handlers.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"dns-api-go/internal/common"
 	"dns-api-go/internal/models"
 	"dns-api-go/internal/services"
 	"dns-api-go/logger"
@@ -17,9 +18,9 @@ type MacAddressParams struct {
 }
 
 type MacParams struct {
-	Address    string            `json:"mac"`
-	PoolId     int               `json:"macpool"`
-	Properties map[string]string `json:"properties"`
+	Address    string `json:"mac"`
+	PoolId     int    `json:"macpool"`
+	Properties string `json:"properties"`
 }
 
 // validateMacAddress validates the format of the MAC address
@@ -70,11 +71,6 @@ func parseCreateMacParams(r *http.Request) (*MacParams, error) {
 		return nil, err
 	}
 
-	// Initialize Properties if nil
-	if MacParams.Properties == nil {
-		MacParams.Properties = make(map[string]string)
-	}
-
 	return &MacParams, nil
 }
 
@@ -101,11 +97,6 @@ func parseUpdateMacParams(r *http.Request) (*MacParams, error) {
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&MacParams); err != nil {
 		return nil, fmt.Errorf("failed to decode request body: %v", err)
-	}
-
-	// Initialize Properties if nil
-	if MacParams.Properties == nil {
-		MacParams.Properties = make(map[string]string)
 	}
 
 	return &MacParams, nil
@@ -150,11 +141,14 @@ func (s *server) CreateMacAddressHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Convert properties into a map
+	propertiesMap := common.ConvertToMap(params.Properties, "|")
+
 	// Create mac object
 	mac := &models.Mac{
 		Address:    params.Address,
 		PoolId:     params.PoolId,
-		Properties: params.Properties,
+		Properties: propertiesMap,
 	}
 
 	// Attempt to create the mac address to bluecat and handle potential errors
@@ -186,11 +180,14 @@ func (s *server) UpdateMacAddressHandler(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Convert properties into a map
+	propertiesMap := common.ConvertToMap(params.Properties, "|")
+
 	// Create new mac object with new properties
 	mac := &models.Mac{
 		Address:    params.Address,
 		PoolId:     params.PoolId,
-		Properties: params.Properties,
+		Properties: propertiesMap,
 	}
 
 	// Update the mac object with the new properties

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -64,5 +64,5 @@ func (s *server) routes() {
 	// Manage MAC addresses
 	accountRouter.HandleFunc("/macs/{mac}", s.GetMacAddressHandler).Methods(http.MethodGet)
 	accountRouter.HandleFunc("/macs", s.CreateMacAddressHandler).Methods(http.MethodPost)
-	accountRouter.HandleFunc("/macs/{mac}", s.CreateMacAddressHandler).Methods(http.MethodPut)
+	accountRouter.HandleFunc("/macs/{mac}", s.UpdateMacAddressHandler).Methods(http.MethodPut)
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -62,6 +62,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/ips/cidrs", s.ProxyRequestHandler).Methods(http.MethodGet)
 
 	// Manage MAC addresses
-	api.HandleFunc("/{account}/macs", s.ProxyRequestHandler).Methods(http.MethodPost, http.MethodPut)
-	api.HandleFunc("/{account}/macs/{mac}", s.ProxyRequestHandler).Methods(http.MethodGet)
+	accountRouter.HandleFunc("/{account}/macs{mac}", s.GetMacAddressHandler).Methods(http.MethodGet)
+	accountRouter.HandleFunc("/{account}/macs", s.CreateMacAddressHandler).Methods(http.MethodPost)
+	accountRouter.HandleFunc("/{account}/macs", s.CreateMacAddressHandler).Methods(http.MethodPut)
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -62,7 +62,7 @@ func (s *server) routes() {
 	api.HandleFunc("/{account}/ips/cidrs", s.ProxyRequestHandler).Methods(http.MethodGet)
 
 	// Manage MAC addresses
-	accountRouter.HandleFunc("/{account}/macs{mac}", s.GetMacAddressHandler).Methods(http.MethodGet)
-	accountRouter.HandleFunc("/{account}/macs", s.CreateMacAddressHandler).Methods(http.MethodPost)
-	accountRouter.HandleFunc("/{account}/macs", s.CreateMacAddressHandler).Methods(http.MethodPut)
+	accountRouter.HandleFunc("/macs/{mac}", s.GetMacAddressHandler).Methods(http.MethodGet)
+	accountRouter.HandleFunc("/macs", s.CreateMacAddressHandler).Methods(http.MethodPost)
+	accountRouter.HandleFunc("/macs/{mac}", s.CreateMacAddressHandler).Methods(http.MethodPut)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -116,7 +116,7 @@ func NewServer(config common.Config) error {
 	baseService := services.NewBaseService(&s)
 	zoneService := services.NewZoneService(&s)
 	networkService := services.NewNetworkService(&s)
-	macAddressService := services.NewMacAddressService(&s, baseService, baseService)
+	macAddressService := services.NewMacAddressService(&s)
 	s.services = Services{
 		BaseService: baseService,
 		ZoneService: zoneService,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -66,6 +66,7 @@ type Services struct {
 	BaseService *services.BaseService
 	ZoneService *services.ZoneService
 	NetworkService *services.NetworkService
+	MacAddressService *services.MacAddressService
 }
 
 type server struct {
@@ -115,10 +116,12 @@ func NewServer(config common.Config) error {
 	baseService := services.NewBaseService(&s)
 	zoneService := services.NewZoneService(&s)
 	networkService := services.NewNetworkService(&s)
+	macAddressService := services.NewMacAddressService(&s, baseService, baseService)
 	s.services = Services{
 		BaseService: baseService,
 		ZoneService: zoneService,
 		NetworkService: networkService,
+		MacAddressService: macAddressService,
 	}
 
 	if b := config.ProxyBackend; b != nil {

--- a/internal/models/mac.go
+++ b/internal/models/mac.go
@@ -1,0 +1,7 @@
+package models
+
+type Mac struct {
+	Address    string
+	PoolId     int
+	Properties map[string]string
+}

--- a/internal/services/mac_address_service.go
+++ b/internal/services/mac_address_service.go
@@ -39,7 +39,7 @@ func (ms *MacAddressService) GetMacAddress(macAddress string) (*models.Entity, e
 
 	// Send http request to bluecat
 	route, params := "/getMACAddress", fmt.Sprintf("configurationId=%d&macAddress=%s", configId, macAddress)
-	resp, err := ms.server.MakeRequest("GET", route, params)
+	resp, err := ms.server.MakeRequest("GET", route, params, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (ms *MacAddressService) AddMacAddress(mac models.Mac, configId int) (int, e
 	route, params := "/addMACAddress", fmt.Sprintf("configurationId=%d&macAddress=%s",
 		configId, mac.Address)
 	params += "&properties=" + common.ConvertToSeparatedString(mac.Properties, "|")
-	resp, err := ms.server.MakeRequest("POST", route, params)
+	resp, err := ms.server.MakeRequest("POST", route, params, nil)
 	if err != nil {
 		return -1, err
 	}
@@ -122,7 +122,7 @@ func (ms *MacAddressService) AssociateMacAddress(mac models.Mac, configId int) e
 	// Send request to bluecat
 	route, params := "/associateMACAddressWithPool", fmt.Sprintf("configurationId=%d&macAddress=%s&poolId=%d",
 		configId, mac.Address, mac.PoolId)
-	resp, err := ms.server.MakeRequest("POST", route, params)
+	resp, err := ms.server.MakeRequest("POST", route, params, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/services/mac_address_service.go
+++ b/internal/services/mac_address_service.go
@@ -18,13 +18,11 @@ type MacAddressEntityService interface {
 
 type MacAddressService struct {
 	server interfaces.ServerInterface
-	interfaces.EntityGetter
-	interfaces.EntityUpdater
 }
 
 // NewMacAddressService Constructor for MacAddressService
-func NewMacAddressService(server interfaces.ServerInterface, entityGetter interfaces.EntityGetter, entityUpater interfaces.EntityUpdater) *MacAddressService {
-	return &MacAddressService{server: server, EntityGetter: entityGetter, EntityUpdater: entityUpater}
+func NewMacAddressService(server interfaces.ServerInterface) *MacAddressService {
+	return &MacAddressService{server: server}
 }
 
 // GetMacAddress Retrieves a mac address entity from bluecat
@@ -173,7 +171,7 @@ func (ms *MacAddressService) UpdateMacAddress(newMac models.Mac) error {
 	}
 
 	// Update entity in bluecat
-	err = ms.EntityUpdater.UpdateEntity(entity)
+	err = UpdateEntity(ms.server, entity)
 	if err != nil {
 		return err
 	}

--- a/internal/services/mac_address_service.go
+++ b/internal/services/mac_address_service.go
@@ -1,0 +1,116 @@
+package services
+
+import (
+	"dns-api-go/internal/interfaces"
+	"dns-api-go/internal/models"
+	"dns-api-go/logger"
+	"encoding/json"
+	"fmt"
+	"go.uber.org/zap"
+)
+
+type MacAddressEntityService interface {
+	GetMacAddress(macAddress string) (*models.Entity, error)
+	CreateMacAddress(mac models.Mac) (int, error)
+	UpdateMacAddress(mac models.Mac, properties map[string]string) error
+}
+
+type MacAddressService struct {
+	server interfaces.ServerInterface
+	interfaces.EntityGetter
+}
+
+// NewMacAddressService Constructor for MacAddressService
+func NewMacAddressService(server interfaces.ServerInterface, entityGetter interfaces.EntityGetter) *MacAddressService {
+	return &MacAddressService{server: server, EntityGetter: entityGetter}
+}
+
+// GetMacAddress Retrieves a mac address entity from bluecat
+func (ms *MacAddressService) GetMacAddress(macAddress string) (*models.Entity, error) {
+	logger.Info("GetMacAddress started", zap.String("macAddress", macAddress))
+
+	// Get the configuration ID
+	configId, err := GetConfigID(ms.server)
+	if err != nil {
+		return nil, err
+	}
+
+	// Send http request to bluecat
+	route, params := "/getMACAddress", fmt.Sprintf("configurationId=%d&macAddress=%s", configId, macAddress)
+	resp, err := ms.server.MakeRequest("GET", route, params)
+	if err != nil {
+		return nil, err
+	}
+	logger.Info("Received response for GetMacAddress", zap.ByteString("response", resp))
+
+	// Unmarshal the response
+	var entityResp models.EntityResponse
+	if err := json.Unmarshal(resp, &entityResp); err != nil {
+		logger.Error("Error unmarshalling entity response", zap.Error(err))
+		return nil, err
+	}
+
+	// Check if the response represents an empty entity
+	if entityResp.IsEmpty() {
+		logger.Info("Entity not found", zap.String("macAddress", macAddress))
+		return nil, &ErrEntityNotFound{}
+	}
+
+	// Convert EntityResponse to Entity
+	entity := entityResp.ToEntity()
+
+	logger.Info("GetMacAddress successful", zap.String("macAddress", macAddress))
+	return &entity, nil
+}
+
+// CreateMacAddress Creates a mac address entity in bluecat
+func (ms *MacAddressService) CreateMacAddress(mac models.Mac) (int, error) {
+	logger.Info("CreateMacAddress started", zap.Any("mac", mac))
+
+	// Get the configuration ID
+	configId, err := GetConfigID(ms.server)
+	if err != nil {
+		return -1, err
+	}
+
+	// Add mac address to bluecat
+	objectId, err := ms.AddMacAddress(mac, configId)
+	if err != nil {
+		return -1, err
+	}
+
+	//
+
+}
+
+// AddMacAddress Adds a mac address entity in bluecat
+func (ms *MacAddressService) AddMacAddress(mac models.Mac, configId int) (int, error) {
+	logger.Info("AddMacAddress started", zap.Any("mac", mac))
+
+	// Send request to bluecat
+	route, params := "/addMACAddress", fmt.Sprintf("configurationId=%d&macAddress=%s&macPoolId=%d",
+		configId, mac.Address, mac.Properties)
+	resp, err := ms.server.MakeRequest("POST", route, params)
+	if err != nil {
+		return -1, err
+	}
+	logger.Info("Received response for AddMacAddress", zap.ByteString("response", resp))
+
+	// Unmarshal the response to get the object iD
+	var objectId int
+	if err := json.Unmarshal(resp, &objectId); err != nil {
+		logger.Error("Error unmarshalling objectId", zap.Error(err))
+		return -1, err
+	}
+
+	return objectId, nil
+}
+
+// AssociateMacAddress Associates a MAC address with a MAC pool in bluecat
+func (ms *MacAddressService) AssociateMacAddress(macAddress string, poolId int, configId int) error {
+	logger.Info("AssociateMacAddress started", zap.String("macAddress", macAddress), zap.Int("poolId", poolId))
+
+	// Send request to bluecat
+	route, params := "/associateMACAddressWithPool", fmt.Sprintf("configurationId=%d&macAddress=%s&macPoolId=%d",
+		configId, macAddress, poolId)
+}

--- a/internal/services/mac_address_service.go
+++ b/internal/services/mac_address_service.go
@@ -140,6 +140,12 @@ func (ms *MacAddressService) AssociateMacAddress(mac models.Mac, configId int) e
 func (ms *MacAddressService) UpdateMacAddress(newMac models.Mac) error {
 	logger.Info("UpdateMacAddress started", zap.Any("New MAC", newMac))
 
+	// Check if mac object exists and if it does, the properties
+	entity, err := ms.GetMacAddress(newMac.Address)
+	if err != nil {
+		return err
+	}
+
 	// Associate mac address with a pool if poolid exists
 	if newMac.PoolId != 0 {
 		// Get the configuration ID
@@ -157,12 +163,6 @@ func (ms *MacAddressService) UpdateMacAddress(newMac models.Mac) error {
 	if len(newMac.Properties) == 0 {
 		logger.Info("No new properties to update")
 		return nil
-	}
-
-	// Get the mac object from inside bluecat to retrieve the properties
-	entity, err := ms.GetMacAddress(newMac.Address)
-	if err != nil {
-		return err
 	}
 
 	// Merge new properties into existing entity properties

--- a/internal/services/mac_errors.go
+++ b/internal/services/mac_errors.go
@@ -1,0 +1,12 @@
+package services
+
+import "fmt"
+
+type PoolIDError struct {
+	PoolID int
+	Err    error
+}
+
+func (e *PoolIDError) Error() string {
+	return fmt.Sprintf("pool ID error: %s, pool ID: %d", e.Err, e.PoolID)
+}


### PR DESCRIPTION
# Testing Guide for MAC Address Service PR

## Overview
To ensure the new Mac Address Service routes are functioning correctly, follow these steps to test each route. Be aware of potential edge cases and ensure comprehensive coverage.

- `GET /macs/{mac}`
- `POST /macs`
- `PUT /macs/{mac}`

## Testing the MAC Address Service Routes

### Testing `GET /macs/{mac}`

**Purpose:** Retrieve a specific MAC address entity.

**Steps:**

1. **Basic Request:**
   - Send a GET request to `/macs/{mac}` with a valid MAC address.
   - Verify that the response status is `200 OK`.
   - Check that the response body contains the correct MAC address entity in JSON format.
   - **Example of Valid MAC Address**: `BC-D0-74-13-50-F0`

2. **MAC Address Format Testing:**
   - Test with various valid MAC address formats:
     - `001122334455`
     - `00:11:22:33:44:55`
     - `00-11-22-33-44-55`
   - Verify that all valid formats are accepted and return the correct entity.

3. **Invalid MAC Address:**
   - Test with invalid MAC addresses:
     - Incorrect format (e.g., `00:11:22:33:44:5`)
     - Invalid characters (e.g., `00:11:22:33:44:GG`)
   - Verify that the response status is `400 Bad Request` with an appropriate error message.

4. **Non-existent MAC Address:**
   - Test with a valid format but non-existent MAC address.
   - Verify that the response status is `404 Not Found` with an appropriate error message.

5. **Case Sensitivity:**
   - Test with mixed case MAC addresses (e.g., `00:aA:Bb:CC:dd:EE`).
   - Verify that the service handles case insensitively.

### Testing `POST /macs`

**Purpose:** Create a new MAC address entity.

**Steps:**

1. **Basic Request:**
   - Send a POST request to `/macs` with a valid JSON body:
     ```json
     {
       "mac": "001122334455",
       "macpool": 1,
       "properties": {
         "key1": "value1",
         "key2": "value2"
       }
     }
     ```
   - Verify that the response status is `200 OK`.
   - Check that the response body contains the object ID of the newly created MAC address.
   - **Example of valid PoolID**: `3610227`
   - Refer to [valid properties for MAC Address entities](https://docs.bluecatnetworks.com/r/Address-Manager-API-Guide/MAC-pool-objects/9.4.0) when passing in properties

2. **MAC Address Format Testing:**
   - Test creation with various valid MAC address formats (as in GET testing).
   - Verify that all valid formats are accepted.

3. **Invalid MAC Address:**
   - Test with invalid MAC addresses in the request body.
   - Verify that the response status is `400 Bad Request` with an appropriate error message.

4. **Missing Required Fields:**
   - Test with a request body missing the `mac` field.
   - Verify that the response status is `400 Bad Request` with an appropriate error message.

5. **Optional Fields:**
   - Test creation without the `macpool` field.
   - Test creation without the `properties` field.
   - Verify that the MAC address is created successfully in both cases.

6. **Duplicate MAC Address:**
   - Attempt to create a MAC address that already exists.
   - Verify that the service handles this appropriately (e.g., `409 Conflict` or updates the existing entry).

7. **Invalid Pool ID:**
   - Test with a non-existent `macpool` ID.
   - Verify that the service handles this error appropriately.

### Testing `PUT /macs/{mac}`

**Purpose:** Update an existing MAC address entity.

**Steps:**

1. **Basic Request:**
   - Send a PUT request to `/macs/{mac}` with a valid MAC address and JSON body:
     ```json
     {
       "macpool": 2,
       "properties": {
         "key3": "value3",
         "key4": "value4"
       }
     }
     ```
   - Verify that the response status is `204 No Content`.
   - **Example of valid PoolID**: `3610227`
   - Refer to [valid properties for MAC Address entities](https://docs.bluecatnetworks.com/r/Address-Manager-API-Guide/MAC-pool-objects/9.4.0) when passing in properties

2. **Updating Pool ID:**
   - Test updating only the `macpool` field.
   - Verify that the MAC address is associated with the new pool.

3. **Updating Properties:**
   - Test updating only the `properties` field.
   - Verify that new properties are added and existing ones are updated.

4. **Non-existent MAC Address:**
   - Attempt to update a non-existent MAC address.
   - Verify that the response status is `404 Not Found` with an appropriate error message.

5. **Invalid MAC Address Format:**
   - Test with an invalid MAC address in the URL.
   - Verify that the response status is `400 Bad Request` with an appropriate error message.

6. **Empty Update:**
   - Send an update request with an empty body.
   - Verify that the service handles this gracefully (e.g., no changes made, successful response).

7. **Partial Updates:**
   - Test updating only a subset of properties.
   - Verify that unmentioned properties remain unchanged.