### PR TITLE
Add Home and Custom Search Routes

### DIFF
--- a/internal/api/entity_handlers.go
+++ b/internal/api/entity_handlers.go
@@ -1,8 +1,51 @@
 package api
 
 import (
+	"dns-api-go/internal/common"
+	"dns-api-go/internal/services"
+	"dns-api-go/internal/types"
+	"dns-api-go/logger"
+	"fmt"
+	"go.uber.org/zap"
 	"net/http"
+	"strings"
 )
+
+type CustomSearchParams struct {
+	filters    map[string]string
+	objectType string
+}
+
+func parseCustomSearchParams(r *http.Request) (*CustomSearchParams, error) {
+	var Params CustomSearchParams
+
+	query := r.URL.Query()
+
+	// Parse filters from the request URL
+	filters := query.Get("filters")
+	if filters == "" {
+		return nil, fmt.Errorf("missing required parameter: filters")
+	}
+	// Convert filters to map, and if empty, it means it was not formatted correctly
+	Params.filters = common.ConvertToMap(filters, "|")
+	if len(Params.filters) == 0 {
+		return nil, fmt.Errorf("invalid filters format")
+	}
+
+	// Parse objectType from the request URL
+	objectType := query.Get("type")
+	if objectType == "" {
+		return nil, fmt.Errorf("missing required parameter: type")
+	}
+	// Make sure the objectType is valid
+	supportedTypes := []string{types.IP4BLOCK, types.IP4NETWORK, types.IP4ADDRESS, types.GENERICRECORD, types.HOSTRECORD}
+	if !common.Contains(supportedTypes, objectType) {
+		return nil, fmt.Errorf("invalid objectType: %s. Supported types are %s", objectType, strings.Join(supportedTypes, ", "))
+	}
+	Params.objectType = objectType
+
+	return &Params, nil
+}
 
 // GetEntityHandler handles GET requests for retrieving an entity by ID.
 func (s *server) GetEntityHandler() http.HandlerFunc {
@@ -12,4 +55,34 @@ func (s *server) GetEntityHandler() http.HandlerFunc {
 // DeleteEntityHandler handles DELETE requests for deleting an entity by ID.
 func (s *server) DeleteEntityHandler() http.HandlerFunc {
 	return s.HandleDeleteEntityReq(s.services.BaseService)
+}
+
+func (s *server) CustomSearchHandler(w http.ResponseWriter, r *http.Request) {
+	logger.Info("CustomSearchHandler started")
+
+	// Parse parameters from the request
+	params, err := parseCustomSearchParams(r)
+	if err != nil {
+		logger.Warn("Invalid request parameters", zap.Error(err))
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Call base service
+	entities, err := s.services.BaseService.CustomSearch(0, 100, params.filters, nil, params.objectType)
+	if err != nil {
+		logger.Error("Error with custom search", zap.Error(err))
+		// Determine thet ype of error and set the HTTP response accordingly
+		switch e := err.(type) {
+		case *services.ErrEntityNotFound:
+			http.Error(w, e.Error(), http.StatusNotFound)
+			return
+		default:
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	logger.Info("CustomSearchHandler successful")
+	s.respond(w, entities, http.StatusOK)
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -23,25 +23,25 @@ import (
 	"strings"
 )
 
-func (s *server) HomeHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) HomeHandler(w http.ResponseWriter, _ *http.Request) {
 	account := []string{s.bluecat.account}
 	s.respond(w, account, http.StatusOK)
 }
 
 // PingHandler responds to ping requests
-func (s *server) PingHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) PingHandler(w http.ResponseWriter, _ *http.Request) {
 	logger.Debug("Ping/Pong")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	s.respond(w, "pong", http.StatusOK)
 }
 
 // VersionHandler responds to version requests
-func (s *server) VersionHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) VersionHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 	s.respond(w, s.version, http.StatusOK)
 }
 
-func (s *server) SystemInfoHandler(w http.ResponseWriter, r *http.Request) {
+func (s *server) SystemInfoHandler(w http.ResponseWriter, _ *http.Request) {
 	body, err := s.MakeRequest("GET", "/getSystemInfo", "", nil)
 	if err != nil {
 		logger.Error("Failed to retrieve system info",

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"dns-api-go/logger"
-	"fmt"
 	"go.uber.org/zap"
 	"net/http"
 	"strings"
@@ -58,48 +57,4 @@ func (s *server) SystemInfoHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Encode the map as JSON and write it to the response
 	s.respond(w, info, http.StatusOK)
-}
-
-func (s *server) GetRecordHintHandler(w http.ResponseWriter, r *http.Request) {
-	// Parse query parameters
-	count := r.URL.Query().Get("count")
-	options := r.URL.Query().Get("options")
-	start := r.URL.Query().Get("start")
-	recordType := r.URL.Query().Get("type")
-
-	// Determine the API endpoint based on the record type
-	var endpoint string
-	switch recordType {
-	case "HostRecord":
-		endpoint = "/getHostRecordsByHint"
-	case "AliasRecord":
-		endpoint = "/getAliasesByHint"
-	default:
-		supportedTypes := []string{"HostRecord", "AliasRecord"}
-		errorMsg := fmt.Sprintf("Invalid record type. Supported types: %s", strings.Join(supportedTypes, ", "))
-		logger.Error("Invalid record type requested",
-			zap.String("recordType", recordType),
-			zap.Strings("supportedTypes", supportedTypes))
-		http.Error(w, errorMsg, http.StatusBadRequest)
-		return
-	}
-
-	// Construct the query parameter string
-	queryParam := fmt.Sprintf("count=%s&options=%s&start=%s", count, options, start)
-
-	// Make the API request
-	body, err := s.MakeRequest("GET", endpoint, queryParam, nil)
-	if err != nil {
-		logger.Error("Failed to make API request for record hint",
-			zap.String("endpoint", endpoint),
-			zap.Error(err))
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	// Set the Content-Type header to application/json
-	w.Header().Set("Content-Type", "application/json")
-
-	// Write the response body as-is
-	w.Write(body)
 }

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -23,6 +23,11 @@ import (
 	"strings"
 )
 
+func (s *server) HomeHandler(w http.ResponseWriter, r *http.Request) {
+	account := []string{s.bluecat.account}
+	s.respond(w, account, http.StatusOK)
+}
+
 // PingHandler responds to ping requests
 func (s *server) PingHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Debug("Ping/Pong")

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -27,7 +27,7 @@ func (s *server) routes() {
 	api.HandleFunc("/ping", s.PingHandler).Methods(http.MethodGet)
 	api.HandleFunc("/version", s.VersionHandler).Methods(http.MethodGet)
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
-	api.HandleFunc("/", s.ProxyRequestHandler).Methods(http.MethodGet)
+	api.HandleFunc("/", s.HomeHandler).Methods(http.MethodGet)
 	api.HandleFunc("/systeminfo", s.SystemInfoHandler).Methods(http.MethodGet)
 
 	// Custom search based on type and filters

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -30,14 +30,14 @@ func (s *server) routes() {
 	api.HandleFunc("/", s.HomeHandler).Methods(http.MethodGet)
 	api.HandleFunc("/systeminfo", s.SystemInfoHandler).Methods(http.MethodGet)
 
-	// Custom search based on type and filters
-	api.HandleFunc("/search", s.ProxyRequestHandler).Methods(http.MethodGet)
-
 	// Create a subrouter for routes that need account validation
 	accountRouter := api.PathPrefix("/{account}").Subrouter()
 
 	// Apply the middleware to all routes in this subrouter
 	accountRouter.Use(s.AccountValidationMiddleware)
+
+	// Custom search based on type and filters
+	accountRouter.HandleFunc("/search", s.CustomSearchHandler).Methods(http.MethodGet)
 
 	// Manage entities by ID
 	accountRouter.HandleFunc("/id/{id}", s.GetEntityHandler()).Methods(http.MethodGet)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -29,7 +29,6 @@ func (s *server) routes() {
 	api.Handle("/metrics", promhttp.Handler()).Methods(http.MethodGet)
 	api.HandleFunc("/", s.ProxyRequestHandler).Methods(http.MethodGet)
 	api.HandleFunc("/systeminfo", s.SystemInfoHandler).Methods(http.MethodGet)
-	api.HandleFunc("/record/hint", s.GetRecordHintHandler).Methods(http.MethodGet)
 
 	// Custom search based on type and filters
 	api.HandleFunc("/search", s.ProxyRequestHandler).Methods(http.MethodGet)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -34,7 +34,7 @@ import (
 )
 
 func init() {
-	rand.Seed(time.Now().UnixNano())
+	rand.New(rand.NewSource(time.Now().UnixNano()))
 }
 
 // apiVersion is the API version

--- a/internal/services/entity_service.go
+++ b/internal/services/entity_service.go
@@ -6,6 +6,7 @@ import (
 	"dns-api-go/internal/types"
 	"dns-api-go/logger"
 	"go.uber.org/zap"
+	"net/url"
 )
 
 type BaseEntityService interface {
@@ -57,4 +58,20 @@ func (es *BaseService) DeleteEntity(id int) error {
 
 	logger.Info("DeleteEntity successful", zap.Int("id", id))
 	return nil
+}
+
+func (es *BaseService) CustomSearch(start int, count int, filters map[string]string, options []string, objectType string) (*[]models.Entity, error) {
+	logger.Info("CustomSearch started",
+		zap.Int("start", start),
+		zap.Int("count", count),
+		zap.Any("filters", filters),
+		zap.Any("options", options),
+		zap.String("objectType", objectType))
+
+	// Construct route and query parameters
+	route := "/customSearch"
+	queryParams := url.Values{}
+
+	logger.Info("CustomSearch successful", zap.Int("count", len(*entities)))
+	return entities, nil
 }

--- a/internal/services/entity_service.go
+++ b/internal/services/entity_service.go
@@ -97,12 +97,6 @@ func (es *BaseService) CustomSearch(start int, count int, filters map[string]str
 		return nil, err
 	}
 
-	// Check if the response is empty
-	if len(entitiesResp) == 0 {
-		logger.Info("No CustomSearch results found")
-		return nil, &ErrEntityNotFound{}
-	}
-
 	// For each entity response, convert it to an entity
 	entities := models.ConvertToEntities(entitiesResp)
 

--- a/internal/services/network_service.go
+++ b/internal/services/network_service.go
@@ -1,56 +1,56 @@
 package services
 
 import (
-	"dns-api-go/internal/interfaces"
-	"dns-api-go/internal/models"
-	"dns-api-go/internal/types"
-	"dns-api-go/logger"
-	"go.uber.org/zap"
+    "dns-api-go/internal/interfaces"
+    "dns-api-go/internal/models"
+    "dns-api-go/internal/types"
+    "dns-api-go/logger"
+    "go.uber.org/zap"
 )
 
 type NetworkEntityService interface {
-	GetEntityByHint(start int, count int, options map[string]string) (*[]models.Entity, error)
-	GetEntity(networkId int, includeHA bool) (*models.Entity, error)
+    GetEntityByHint(start int, count int, options map[string]string) (*[]models.Entity, error)
+    GetEntity(networkId int, includeHA bool) (*models.Entity, error)
 }
 
 type NetworkService struct {
-	server interfaces.ServerInterface
+    server interfaces.ServerInterface
 }
 
 // NewNetworkService Constructor for NetworkService
 func NewNetworkService(server interfaces.ServerInterface) *NetworkService {
-	return &NetworkService{server: server}
+    return &NetworkService{server: server}
 }
 
 // GetEntitiesByHint Retrieves a list of networks from bluecat
 // Note: The maximum that count can be is 10.
 func (ns *NetworkService) GetEntitiesByHint(start int, count int, options map[string]string) (*[]models.Entity, error) {
-	logger.Info("GetEntitiesByHint started",
-		zap.Int("start", start),
-		zap.Int("count", count),
-		zap.Any("options", options))
+    logger.Info("GetEntitiesByHint started",
+        zap.Int("start", start),
+        zap.Int("count", count),
+        zap.Any("options", options))
 
-	route := "/getIP4NetworksByHint"
-	networks, err := GetEntitiesByHintHelper(ns.server, route, start, count, options)
-	if err != nil {
-		return nil, err
-	}
+    route := "/getIP4NetworksByHint"
+    networks, err := GetEntitiesByHintHelper(ns.server, route, start, count, options)
+    if err != nil {
+        return nil, err
+    }
 
-	logger.Info("GetEntitiesByHint successful", zap.Int("count", len(*networks)))
-	return networks, nil
+    logger.Info("GetEntitiesByHint successful", zap.Int("count", len(*networks)))
+    return networks, nil
 }
 
 func (ns *NetworkService) GetEntity(networkId int, includeHA bool) (*models.Entity, error) {
-	logger.Info("GetNetwork started", zap.Int("networkId", networkId))
+    logger.Info("GetNetwork started", zap.Int("networkId", networkId))
 
-	// Call EntityGetter
-	entity, err := GetEntityByID(ns.server, networkId, includeHA, []string{types.NETWORK})
-	if err != nil {
-		return nil, err
-	}
+    // Call EntityGetter
+    entity, err := GetEntityByID(ns.server, networkId, includeHA, []string{types.IP4NETWORK})
+    if err != nil {
+        return nil, err
+    }
 
-	logger.Info("GetNetwork successful",
-		zap.Int("entityId", entity.ID),
-		zap.String("entityType", entity.Type))
-	return entity, nil
+    logger.Info("GetNetwork successful",
+        zap.Int("entityId", entity.ID),
+        zap.String("entityType", entity.Type))
+    return entity, nil
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,14 +1,22 @@
 package types
 
 const (
-	CNAMERECORD   = "AliasRecord"
 	CONFIGURATION = "Configuration"
 	ENTITY        = "Entity"
+	CNAMERECORD   = "AliasRecord"
 	EXTERNALHOST  = "ExternalHostRecord"
 	HOSTRECORD    = "HostRecord"
+	GENERICRECORD = "GenericRecord"
+	HINFORECORD   = "HINFORecord"
+	MXRECORD      = "MXRecord"
+	SRVRECORD     = "SRVRecord"
+	TXTRECORD     = "TXTRecord"
 	IP4ADDRESS    = "IP4Address"
+	IP4BLOCK      = "IP4Block"
+	IP4NETWORK    = "IP4Network"
 	MACADDRESS    = "MACAddress"
 	MACPOOL       = "MACPool"
 	ZONE          = "Zone"
-	NETWORK       = "IP4Network"
+	DHCP4RANGE    = "DHCP4Range"
+	VIEW          = "View"
 )


### PR DESCRIPTION
# Testing Guide for Home and Custom Search PR

## Overview
This guide outlines the testing procedures for the newly implemented Home route and Custom Search route in our DNS Go API application. The routes to be tested are:

- `GET /` (Home route)
- `GET /{account}/search` (Custom Search route)

## Testing the Home Route

### Testing `GET /`

**Purpose:** Retrieve the Bluecat account information.

**Steps:**

1. **Basic Request:**
   - Send a GET request to `/`.
   - Verify that the response status is `200 OK`.
   - Check that the response body contains a JSON array with a single string element "bam-test".

## Testing the Custom Search Route

### Testing `GET /{account}/search`

**Purpose:** Perform a custom search based on type and filters.

**Steps:**

1. **Basic Request:**
   - Send a GET request to `/account/search` with required parameters:
     `/account/search?type=IP4BLOCK&filters=name=example`
   - Verify that the response status is `200 OK`.
   - Check that the response body contains a JSON array of entity objects.

2. **Pagination:**
   - Test with different `offset` and `limit` values:
     `/account/search?type=IP4BLOCK&filters=name=example&offset=0&limit=10`
     `/account/search?type=IP4BLOCK&filters=name=example&offset=10&limit=20`
   - Verify that the correct number of entities is returned based on the `limit`.
   - Verify that the entities start from the correct `offset`.

3. **Object Types:**
   - Test with each supported object type:
     - IP4BLOCK
     - IP4NETWORK
     - IP4ADDRESS
     - GENERICRECORD
     - HOSTRECORD
   - Verify that only entities of the specified type are returned.
   - Test with an unsupported object type and verify a `400 Bad Request` response.

4. **Filters:**
   - Test with various filter combinations:
     `/account/search?type=IP4BLOCK&filters=name=example|cidr=192.168.0.0/24`
   - Verify that the returned entities match the specified filters.
   - Test with empty filters and verify a `400 Bad Request` response.
   - Test with incorrectly formatted filters and verify a `400 Bad Request` response.
   - Refer to the [BlueCat Address Manager API Guide](https://docs.bluecatnetworks.com/r/Address-Manager-API-Guide/Custom-search/9.4.0) to find out what filters are applicable for each supported object type. Use this information to test a variety of valid and invalid filters for each object type.

5. **Invalid Parameters:**
   - Test with negative `offset` and `limit` values.
   - Test with non-integer `offset` and `limit` values.
   - Verify that the response status is `400 Bad Request` with appropriate error messages.

6. **Missing Required Parameters:**
   - Test without the `type` parameter.
   - Test without the `filters` parameter.
   - Verify that the response status is `400 Bad Request` with appropriate error messages.

7. **Empty Result:**
   - Test with search criteria that should return no results.
   - Verify that an empty array is returned with a `200 OK` status.